### PR TITLE
设置nodeIntegration属性为true

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -9,7 +9,13 @@ const quickClipboard = require('../lib');
 let mainWindow;
 
 function createWindow() {
-  mainWindow = new BrowserWindow({width: 800, height: 600})
+  mainWindow = new BrowserWindow({
+    width: 800, 
+    height: 600, 
+    webPreferences: {
+      nodeIntegration: true
+    }
+  })
   mainWindow.loadURL(url.format({
     pathname: path.join(__dirname, 'index.html'),
     protocol: 'file:',

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,9 @@ let createClipWindow = () => {
     backgroundColor: '#fff',
     x: 0, y: size.height - height,
     show: false,
+    webPreferences: {
+      nodeIntegration:true
+    }
   });
   // clipWin.openDevTools(); // for dev
   clipWin.loadURL(modalPath);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quick-clipboard",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Electron 5.0将nodeIntegration默认设置为false，需要手动设置为true，才能在渲染进程使用node api